### PR TITLE
Save drawing as a download instead of opening a new window

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -387,7 +387,17 @@ function onMenuSave()
 {
 	// window.open(canvas.toDataURL('image/png'),'mywindow');
 	flatten();
-	window.open(flattenCanvas.toDataURL('image/png'),'mywindow');
+	flattenCanvas.toBlob(function(blob)
+	{
+		var url = URL.createObjectURL(blob);
+		var link = document.createElement('a');
+		link.download = 'harmony.png';
+		link.href = url;
+		document.body.appendChild(link);
+		link.click();
+		document.body.removeChild(link);
+		URL.revokeObjectURL(url);
+	}, 'image/png');
 }
 
 function onMenuClear()


### PR DESCRIPTION
Fix a bug: onMenuSave previously called window.open() with the canvas data URL, which just displayed the image in a new tab/window. Replace it with a temporary anchor that triggers a download of harmony.png.

Use canvas.toBlob() + URL.createObjectURL() rather than an anchor with a toDataURL() href: Safari ignores the download attribute on data: URLs (opening the image instead of saving it), and Firefox only fires the click reliably when the anchor is attached to the DOM. 
A blob URL fixes both and avoids building a large base64 string for big canvases.