### PR TITLE
Fix overlapping opacity dots by redrawing stroke as single path

### DIFF
--- a/js/brushes/simple.js
+++ b/js/brushes/simple.js
@@ -7,7 +7,8 @@ simple.prototype =
 {
 	context: null,
 
-	prevMouseX: null, prevMouseY: null,
+	points: null,
+	snapshot: null,
 
 	init: function( context )
 	{
@@ -21,26 +22,34 @@ simple.prototype =
 
 	strokeStart: function( mouseX, mouseY )
 	{
-		this.prevMouseX = mouseX;
-		this.prevMouseY = mouseY;
+		this.points = [ { x: mouseX, y: mouseY } ];
+
+		this.snapshot = this.context.getImageData( 0, 0, this.context.canvas.width, this.context.canvas.height );
 	},
 
 	stroke: function( mouseX, mouseY )
 	{
-		this.context.lineWidth = BRUSH_SIZE;	
-		this.context.strokeStyle = "rgba(" + COLOR[0] + ", " + COLOR[1] + ", " + COLOR[2] + ", " + 0.5 * BRUSH_PRESSURE + ")";
-		
-		this.context.beginPath();
-		this.context.moveTo(this.prevMouseX, this.prevMouseY);
-		this.context.lineTo(mouseX, mouseY);
-		this.context.stroke();
+		this.points.push( { x: mouseX, y: mouseY } );
 
-		this.prevMouseX = mouseX;
-		this.prevMouseY = mouseY;
+		this.context.putImageData( this.snapshot, 0, 0 );
+
+		this.context.lineWidth = BRUSH_SIZE;
+		this.context.lineCap = BRUSH_SIZE == 1 ? 'butt' : 'round';
+		this.context.lineJoin = 'round';
+		this.context.strokeStyle = "rgba(" + COLOR[0] + ", " + COLOR[1] + ", " + COLOR[2] + ", " + 0.5 * BRUSH_PRESSURE + ")";
+
+		this.context.beginPath();
+		this.context.moveTo( this.points[0].x, this.points[0].y );
+
+		for ( var i = 1, l = this.points.length; i < l; i ++ )
+			this.context.lineTo( this.points[i].x, this.points[i].y );
+
+		this.context.stroke();
 	},
 
 	strokeEnd: function()
 	{
-		
+		this.points = null;
+		this.snapshot = null;
 	}
 }


### PR DESCRIPTION
As part of the features from my fork, this adds a suggested fix for the circular dots that appear along lines (most visible with the simple brush with brush size > 1). They're caused by semi-transparent segments overlapping at every join, which darkens those spots.

To be upfront about the trade-offs:

- Performance: the stroke is redrawn on every mouse move, so it's O(n²) over the length of a stroke. This may need more work if pressure-pen support is ever added back.
- Intent: it's possible the original behavior was intentional, or that some artists relied on that look. I wasn't sure but i decide to suggest it anyway. 

Before: 
<img width="414" height="438" alt="Screenshot 2026-07-07 at 10 41 36" src="https://github.com/user-attachments/assets/683c5918-fe8c-412a-99de-1dde672bd62d" />

After: 
<img width="651" height="503" alt="Screenshot 2026-07-07 at 10 37 31" src="https://github.com/user-attachments/assets/a8a3ac2c-0565-4d17-acea-d2d32621729c" />

Not same tests storkes but since it is easy to see and visible always, i think it is not important. 


Tested on: Safari + Chrome (OSX). 



