### PR TITLE
Show color wheel only when Shift is pressed without modifiers. 

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -207,11 +207,20 @@ function onWindowResize()
 function onWindowKeyDown( event )
 {
 	if (shiftKeyIsDown)
+	{
+		if (event.metaKey || event.ctrlKey || event.altKey)
+		{
+			shiftKeyIsDown = false;
+			foregroundColorSelector.container.style.visibility = 'hidden';
+		}
 		return;
+	}
 
 	switch(event.keyCode)
 	{
 		case 16: // Shift
+			if (event.metaKey || event.ctrlKey || event.altKey)
+				break;
 			shiftKeyIsDown = true;
 			foregroundColorSelector.container.style.left = mouseX - 125 + 'px';
 			foregroundColorSelector.container.style.top = mouseY - 125 + 'px';


### PR DESCRIPTION
Ignore Shift when combined with another modifier (Cmd/Ctrl/Alt) so OSX screenshot shortcuts (Cmd+Shift+1..4) no longer trigger the color wheel.
This small fix help as i find out that harmony artists (at least one that i know well personally) sometimes want to just take a screenshot of selected area instead of download the png file. IN OSX is really an issue



Tested: Safari+Chrome (OSX). 